### PR TITLE
🐛在ios或Mac上正则报错

### DIFF
--- a/js/js.js
+++ b/js/js.js
@@ -400,7 +400,7 @@ function aeiouy(word) {
     word1 = word1.replace(/<\/>/g, "</span>");
     word1 = word1.replace(/< >/g, '<span class="fu">');
     word1 = word1.replace(/<\/ >/g, "</span>");
-    word2 = word.replace(/([aeiou])|(?<=[^aeiou])y/g, '<span class="aeiouy">$&</span>');
+    word2 = word.replace(/([aeiou])|(?:[^aeiou])y/g, '<span class="aeiouy">$&</span>');
     // word = word.replace(/([aeiou])[^aeiou](e)/g, '<span class="aeiou_e">$&</span>')
 
     return [word1, word2];


### PR DESCRIPTION
正则从 /([aeiou])|(?<=[^aeiou])?y/g 改为/([aeiou])|(?:[^aeiou])?y/g
这样子会修正报错，但是行为将改变
```
> var a = new RegExp(/([aeiou])|(?:[^aeiou])y/g);
> "ayy".replace(a, '<span class="aeiouy">$&</span>')
< "<span class=\"aeiouy\">a</span><span class=\"aeiouy\">yy</span>"
```